### PR TITLE
Cleaned up some memory leaks

### DIFF
--- a/gofst.cpp
+++ b/gofst.cpp
@@ -171,6 +171,12 @@ CSymbolTable SymbolTableInit()
   return (CSymbolTable)st;
 }
 
+void SymbolTableFree(CSymbolTable st)
+{
+  SymbolTable * st_ = (SymbolTable*)st;
+  delete st_;
+}
+
 
 int SymbolTableEqual(CSymbolTable st1, CSymbolTable st2)
 {
@@ -203,10 +209,7 @@ char* SymbolTableFindSymbol(CSymbolTable st, int key)
   
   SymbolTable * st_ = (SymbolTable*) st;
   string symbol = st_->Find(key);
-  int l = symbol.length() + 1;
-  char *c =  new char[l];
-  strcpy(c, symbol.c_str());
-  return c;
+  return (char *)(symbol.c_str());
 }
 
 int SymbolTableHasKey(CSymbolTable st, int key){
@@ -279,6 +282,12 @@ CStateIterator StateIteratorInit(CFst fst)
   return (CStateIterator)siter;
 }
 
+void StateIteratorFree(CStateIterator siter)
+{
+  StateIterator<StdFst> * siter_ = (StateIterator<StdFst>*)siter;
+  delete siter_;
+}
+
 void StateIteratorNext(CStateIterator si)
 {
   StateIterator<StdFst> * siter = (StateIterator<StdFst> *)si;
@@ -303,6 +312,12 @@ CArc ArcInit(int ilabel,int olabel,float weight,int state_id)
 {
   StdArc * arc = new StdArc(ilabel, olabel, weight, state_id);
   return (CArc*) arc;
+}
+
+void ArcFree(CArc arc)
+{
+  StdArc * arc_ = (StdArc*)arc;
+  delete arc_;
 }
 
 int ArcGetILabel(CArc arc) {
@@ -334,6 +349,12 @@ CArcIterator ArcIteratorInit(CFst fst, CStateId state_id)
   StdVectorFst * fst_ = (StdVectorFst*)fst;
   ArcIterator<Fst<StdArc>> * aiter = new ArcIterator<Fst<StdArc>>(*fst_, state_id);
   return (CArcIterator)aiter;
+}
+
+void ArcIteratorFree(CArcIterator aiter)
+{
+  ArcIterator<Fst<StdArc>> * aiter_ = (ArcIterator<Fst<StdArc>>*)aiter;
+  delete aiter_;
 }
 
 void ArcIteratorNext(CArcIterator ai)

--- a/gofst.go
+++ b/gofst.go
@@ -4,7 +4,9 @@ package gofst
 // #cgo CXXFLAGS: -std=c++11
 // #cgo LDFLAGS: -L/usr/local/lib -lfst
 // #include "gofst.h"
+// #include "stdlib.h"
 import "C"
+import "unsafe"
 
 //Fst structy
 type Fst struct {
@@ -77,12 +79,14 @@ func (f Fst) AddArc(src int, tgt int, isym string, osym string, weight float64) 
 		olabel = f.osyms.AddSymbol(osym)
 	}
 	arc := ArcInit(int(ilabel), int(olabel), weight, tgt)
+	defer arc.Free()
 	C.FstAddArc(f.cfst, C.int(src), arc.carc)
 }
 
 //memory leak free variant of adding arc
 func (f Fst) AddArcBySymbolKey(src int, tgt int, isym int, osym int, weight float64) {
 	arc := ArcInit(isym, osym, weight, tgt)
+	defer arc.Free()
 	C.FstAddArc(f.cfst, C.int(src), arc.carc)
 }
 
@@ -150,7 +154,9 @@ func (f Fst) ArcSortOuput() {
 
 //Write write FST to file
 func (f Fst) Write(filename string) {
-	C.FstWrite(f.cfst, (C.CString)(filename))
+	cs := (C.CString)(filename)
+	defer C.free(unsafe.Pointer(cs))
+	C.FstWrite(f.cfst, cs)
 }
 
 //SetInputSymbols set FST input SymbolTable
@@ -176,7 +182,9 @@ func (f *Fst) OutputSymbols() SymbolTable {
 //FstRead read FST from file
 func FstRead(filename string) Fst {
 	var ret Fst
-	ret.cfst = C.FstRead((C.CString)(filename))
+	cs := (C.CString)(filename)
+	defer C.free(unsafe.Pointer(cs))
+	ret.cfst = C.FstRead(cs)
 	return ret
 }
 
@@ -189,13 +197,17 @@ func SymbolTableInit() SymbolTable {
 	return ret
 }
 
-func (st SymbolTable) FindKey(symbol string) int {
-	return int(C.SymbolTableFindKey(st.csyms, C.CString(symbol)))
+func (st SymbolTable) Free() {
+	C.SymbolTableFree(st.csyms)
 }
 
-//memory leak here, what causes it? maybe csymbol?
+func (st SymbolTable) FindKey(symbol string) int {
+	cs := (C.CString)(symbol)
+	defer C.free(unsafe.Pointer(cs))
+	return int(C.SymbolTableFindKey(st.csyms, cs))
+}
+
 func (st SymbolTable) FindSymbol(key int) string {
-	//defer C.FreeString(csymbol)
 	return C.GoString(C.SymbolTableFindSymbol(st.csyms, C.int(key)))
 
 }
@@ -205,32 +217,44 @@ func (st SymbolTable) HasKey(key int) bool {
 }
 
 func (st SymbolTable) HasSymbol(symbol string) bool {
-	return C.SymbolTableHasSymbol(st.csyms, C.CString(symbol)) > 0
+	cs := (C.CString)(symbol)
+	defer C.free(unsafe.Pointer(cs))
+	return C.SymbolTableHasSymbol(st.csyms, cs) > 0
 }
 
 func (st SymbolTable) AddSymbol(symbol string) int {
-	return int(C.SymbolTableAddSymbol(st.csyms, C.CString(symbol)))
+	cs := (C.CString)(symbol)
+	defer C.free(unsafe.Pointer(cs))
+	return int(C.SymbolTableAddSymbol(st.csyms, cs))
 }
 
 func (st SymbolTable) AddSymbolKey(symbol string, key int) int {
-	return int(C.SymbolTableAddSymbolKey(st.csyms, C.CString(symbol), C.int(key)))
+	cs := (C.CString)(symbol)
+	defer C.free(unsafe.Pointer(cs))
+	return int(C.SymbolTableAddSymbolKey(st.csyms, cs, C.int(key)))
 }
 
 func SymbolTableReadText(filename string) SymbolTable {
 	var ret SymbolTable
-	ret.csyms = C.SymbolTableReadText((C.CString)(filename))
+	cs := (C.CString)(filename)
+	defer C.free(unsafe.Pointer(cs))
+	ret.csyms = C.SymbolTableReadText(cs)
 	return ret
 }
 
 func SymbolTableRead(filename string) SymbolTable {
 	var ret SymbolTable
-	ret.csyms = C.SymbolTableReadBinary((C.CString)(filename))
+	cs := (C.CString)(filename)
+	defer C.free(unsafe.Pointer(cs))
+	ret.csyms = C.SymbolTableReadBinary(cs)
 	return ret
 }
 
 //Write write FST to file
 func (st SymbolTable) Write(filename string) {
-	C.SymbolTableWrite(st.csyms, (C.CString)(filename))
+	cs := (C.CString)(filename)
+	defer C.free(unsafe.Pointer(cs))
+	C.SymbolTableWrite(st.csyms, cs)
 }
 
 // Iterator
@@ -259,6 +283,10 @@ func StateIteratorInit(fst Fst) StateIterator {
 	var siter StateIterator
 	siter.csiter = C.StateIteratorInit(fst.cfst)
 	return siter
+}
+
+func (siter StateIterator) Free() {
+	C.StateIteratorFree(siter.csiter)
 }
 
 func (siter StateIterator) Next() {
@@ -314,10 +342,18 @@ func ArcInit(ilabel int, olabel int, weight float64, state_id int) Arc {
 	return ret
 }
 
+func (arc Arc) Free() {
+	C.ArcFree(arc.carc)
+}
+
 func ArcIteratorInit(fst Fst, state_id int) ArcIterator {
 	var aiter ArcIterator
 	aiter.caiter = C.ArcIteratorInit(fst.cfst, C.int(state_id))
 	return aiter
+}
+
+func (aiter ArcIterator) Free() {
+	C.ArcIteratorFree(aiter.caiter)
 }
 
 func (aiter ArcIterator) Next() {

--- a/gofst.h
+++ b/gofst.h
@@ -59,6 +59,7 @@ extern "C" {
 
   /**********Symboltable**********/
   CSymbolTable SymbolTableInit(void);
+  void SymbolTableFree(CSymbolTable st);
 
   int SymbolTableEqual(CSymbolTable st1, CSymbolTable st2);
 
@@ -84,6 +85,7 @@ extern "C" {
   typedef int CStateId;
   typedef void* CStateIterator;
   CStateIterator StateIteratorInit(CFst fst);
+  void StateIteratorFree(CStateIterator aiter);
   void StateIteratorNext(CStateIterator si);
   CStateId StateIteratorValue(CStateIterator si);
   int StateIteratorDone(CStateIterator si);
@@ -96,7 +98,7 @@ extern "C" {
 
   /**********Arc**********/
   CArc ArcInit(int ilabel,int olabel,float weight,int state_id);
-
+  void ArcFree(CArc arc);
   int ArcGetILabel(CArc arc);
   int ArcGetOLabel(CArc arc);
   float ArcGetWeight(CArc arc);
@@ -105,6 +107,7 @@ extern "C" {
   
   typedef void* CArcIterator;
   CArcIterator ArcIteratorInit(CFst fst, int state_id);
+  void ArcIteratorFree(CArcIterator aiter);
   void ArcIteratorNext(CArcIterator ai);
   CArc ArcIteratorValue(CArcIterator ai);
   int ArcIteratorDone(CArcIterator ai);

--- a/gofst_test.go
+++ b/gofst_test.go
@@ -8,13 +8,14 @@ import (
 
 func TestBasic(t *testing.T) {
 	fst := FstInit()
+	defer fst.Free()
 	fst.AddState()
 	fst.SetStart(0)
-	fst.Free()
 }
 
 func TestIsFinal(t *testing.T) {
 	fst := FstInit()
+	defer fst.Free()
 	fst.AddState()
 	fst.AddState()
 	fst.AddState()
@@ -61,7 +62,9 @@ func TestMinimize(t *testing.T) {
 func TestStateIterator(t *testing.T) {
 	input := FstRead("ex01/Marsman_t.fst")
 	fmt.Println("start state iterate")
-	for siter := StateIteratorInit(input); !siter.Done(); siter.Next() {
+	siter := StateIteratorInit(input)
+	defer siter.Free()
+	for ; !siter.Done(); siter.Next() {
 		fmt.Println(siter.Value())
 	}
 }
@@ -72,7 +75,9 @@ func TestArcIterator(t *testing.T) {
 	for siter := StateIteratorInit(input); !siter.Done(); siter.Next() {
 		state := siter.Value()
 		fmt.Println(state)
-		for aiter := ArcIteratorInit(input, state); !aiter.Done(); aiter.Next() {
+		aiter := ArcIteratorInit(input, state)
+		defer aiter.Free()
+		for ; !aiter.Done(); aiter.Next() {
 			arc := aiter.Value()
 			fmt.Println(arc.GetILabel(), arc.GetOLabel(), arc.GetWeight(), arc.GetNextState())
 		}
@@ -99,6 +104,7 @@ func TestSymbolTableRead(t *testing.T) {
 
 func TestSymbolTableWrite(t *testing.T) {
 	syms := SymbolTableInit()
+	defer syms.Free()
 
 	syms.AddSymbolKey("开始", 9)
 	fmt.Println("add 开始")
@@ -124,6 +130,7 @@ func TestSymbolTableWrite(t *testing.T) {
 
 func TestSymbolTableHasSymbol(t *testing.T) {
 	syms := SymbolTableInit()
+	defer syms.Free()
 
 	syms.AddSymbolKey("开始", 9)
 	fmt.Println("add 开始")
@@ -151,6 +158,11 @@ func TestSymbolTableHasSymbol(t *testing.T) {
 func TestSymbolTableSetSymbolTable(t *testing.T) {
 	fst := FstInit()
 	isyms := SymbolTableInit()
+	defer func() {
+		isyms.Free()
+		fst.Free()
+	}()
+
 	fst.SetInputSymbols(isyms)
 
 	syms1 := fst.isyms
@@ -178,8 +190,15 @@ func TestSymbolTableSetSymbolTable(t *testing.T) {
 
 func TestFstAddArc(t *testing.T) {
 	fst := FstInit()
-	fst.SetInputSymbols(SymbolTableInit())
-	fst.SetOutputSymbols(SymbolTableInit())
+	isyms := SymbolTableInit()
+	osyms := SymbolTableInit()
+	defer func() {
+		defer fst.Free()
+		defer isyms.Free()
+		defer osyms.Free()
+	}()
+	fst.SetInputSymbols(isyms)
+	fst.SetOutputSymbols(osyms)
 
 	fst.AddState()
 	fst.AddState()
@@ -213,10 +232,14 @@ func TestFstAddArc(t *testing.T) {
 	fst = FstRead("addarc.fst")
 
 	fmt.Println("start state iterate")
-	for siter := StateIteratorInit(fst); !siter.Done(); siter.Next() {
+	siter := StateIteratorInit(fst)
+	defer siter.Free()
+	for ; !siter.Done(); siter.Next() {
 		state := siter.Value()
 		fmt.Println(state)
-		for aiter := ArcIteratorInit(fst, state); !aiter.Done(); aiter.Next() {
+		aiter := ArcIteratorInit(fst, state)
+		defer aiter.Free()
+		for ; !aiter.Done(); aiter.Next() {
 			arc := aiter.Value()
 			fmt.Println(arc.GetILabel(), arc.GetOLabel(), arc.GetWeight(), arc.GetNextState())
 		}
@@ -226,6 +249,7 @@ func TestFstAddArc(t *testing.T) {
 
 func TestFstPaths(t *testing.T) {
 	fst := FstInit()
+	defer fst.Free()
 	fst.SetInputSymbols(SymbolTableInit())
 	fst.SetOutputSymbols(SymbolTableInit())
 


### PR DESCRIPTION
Hi, i found some memory leaks in your code. Here my suggestion to clean them up
1. Free memory after using CString according to official [cgo documentation.](https://golang.org/cmd/cgo/#hdr-Go_references_to_C)

```
// Go string to C string
// The C string is allocated in the C heap using malloc.
// It is the caller's responsibility to arrange for it to be
// freed, such as by calling C.free (be sure to include stdlib.h
// if C.free is needed).
func C.CString(string) *C.char
```
2.  `SymbolTable, ArcIterator, StateIteraror, Arc` are allocated by `new`. I added `Free()` method to release memory when you don´t need resource created by `xxxInit()`.

3.  Remove copying from `SymbolTableFindSymbol` in `gofst.cpp`. I don´t think it is necessary.

I also added memory release to the tests so that it’s clear how to work with the library