### PR TITLE
fix(symtable): copy val where pointer to local cstring returned

### DIFF
--- a/gofst.cpp
+++ b/gofst.cpp
@@ -223,12 +223,14 @@ int SymbolTableFindKey(CSymbolTable st, char *symbol)
   SymbolTable * st_ = (SymbolTable*) st;
   return st_->Find(symbol);
 }
+
 char* SymbolTableFindSymbol(CSymbolTable st, int key)
 {
-  
   SymbolTable * st_ = (SymbolTable*) st;
   string symbol = st_->Find(key);
-  return (char *)(symbol.c_str());
+  char *symbol_cstr = new char[symbol.size()];
+  strncpy(symbol_cstr, symbol.c_str(), symbol.size());
+  return symbol_cstr;
 }
 
 int SymbolTableHasKey(CSymbolTable st, int key){

--- a/gofst.cpp
+++ b/gofst.cpp
@@ -228,8 +228,9 @@ char* SymbolTableFindSymbol(CSymbolTable st, int key)
 {
   SymbolTable * st_ = (SymbolTable*) st;
   string symbol = st_->Find(key);
-  char *symbol_cstr = new char[symbol.size()];
+  char *symbol_cstr = new char[symbol.size() + 1];
   strncpy(symbol_cstr, symbol.c_str(), symbol.size());
+  symbol_cstr[symbol.size()] = '\0';
   return symbol_cstr;
 }
 


### PR DESCRIPTION
Might be a possible reason for the issue, why sometimes last symbols in fst get corrupted.